### PR TITLE
Supply messages for 404 responses instead of using HTML page fallback…

### DIFF
--- a/app/src/main/java/io/sparkled/App.java
+++ b/app/src/main/java/io/sparkled/App.java
@@ -1,6 +1,7 @@
 package io.sparkled;
 
 import com.google.inject.persist.PersistService;
+import io.sparkled.rest.RestApiServer;
 import io.sparkled.schema.SchemaUpdater;
 import io.sparkled.udpserver.UdpServer;
 

--- a/app/src/main/java/io/sparkled/Main.java
+++ b/app/src/main/java/io/sparkled/Main.java
@@ -4,7 +4,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import io.sparkled.inject.RestApiServerModule;
+import io.sparkled.rest.inject.RestApiServerModule;
 import io.sparkled.music.inject.MusicPlayerModule;
 import io.sparkled.persistence.inject.PersistenceModule;
 import io.sparkled.schema.inject.SchemaModule;

--- a/rest/src/main/java/io/sparkled/rest/RestApiServer.java
+++ b/rest/src/main/java/io/sparkled/rest/RestApiServer.java
@@ -1,4 +1,4 @@
-package io.sparkled;
+package io.sparkled.rest;
 
 /**
  * A REST API Server that listens on the given port.

--- a/rest/src/main/java/io/sparkled/rest/RestApiServerImpl.java
+++ b/rest/src/main/java/io/sparkled/rest/RestApiServerImpl.java
@@ -1,7 +1,9 @@
-package io.sparkled;
+package io.sparkled.rest;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Injector;
+import io.sparkled.rest.jetty.JerseyResourceConfig;
+import io.sparkled.rest.jetty.TryFilesFilter;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
@@ -60,7 +62,7 @@ public class RestApiServerImpl implements RestApiServer {
         ServletContextHandler context = createContextHandler();
         addStaticResourceConfig(context);
         addJerseyServlet(context);
-        initCorsFilter(context);
+        addCorsFilter(context);
 
         jettyServer.setHandler(context);
         startJetty(jettyServer);
@@ -101,7 +103,7 @@ public class RestApiServerImpl implements RestApiServer {
         jerseyServlet.setInitOrder(0);
     }
 
-    private void initCorsFilter(ServletContextHandler context) {
+    private void addCorsFilter(ServletContextHandler context) {
         FilterHolder corsFilter = context.addFilter(CrossOriginFilter.class, REST_PATH, EnumSet.of(DispatcherType.REQUEST));
         corsFilter.setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, "*");
         corsFilter.setInitParameter(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "*");

--- a/rest/src/main/java/io/sparkled/rest/inject/RestApiServerModule.java
+++ b/rest/src/main/java/io/sparkled/rest/inject/RestApiServerModule.java
@@ -1,8 +1,8 @@
-package io.sparkled.inject;
+package io.sparkled.rest.inject;
 
 import com.google.inject.AbstractModule;
-import io.sparkled.RestApiServer;
-import io.sparkled.RestApiServerImpl;
+import io.sparkled.rest.RestApiServer;
+import io.sparkled.rest.RestApiServerImpl;
 import io.sparkled.viewmodel.playlist.PlaylistViewModelConverter;
 import io.sparkled.viewmodel.playlist.PlaylistViewModelConverterImpl;
 import io.sparkled.viewmodel.playlist.search.PlaylistSearchViewModelConverter;

--- a/rest/src/main/java/io/sparkled/rest/jetty/GenericExceptionMapper.java
+++ b/rest/src/main/java/io/sparkled/rest/jetty/GenericExceptionMapper.java
@@ -1,4 +1,4 @@
-package io.sparkled.rest;
+package io.sparkled.rest.jetty;
 
 import io.sparkled.model.validator.exception.EntityValidationException;
 import io.sparkled.viewmodel.exception.ViewModelConversionException;

--- a/rest/src/main/java/io/sparkled/rest/jetty/JerseyResourceConfig.java
+++ b/rest/src/main/java/io/sparkled/rest/jetty/JerseyResourceConfig.java
@@ -1,4 +1,4 @@
-package io.sparkled;
+package io.sparkled.rest.jetty;
 
 import com.google.inject.Injector;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -18,7 +18,7 @@ public class JerseyResourceConfig extends ResourceConfig {
     private static Logger logger = LoggerFactory.getLogger(JerseyResourceConfig.class);
     private static Injector injector;
 
-    static void setInjector(Injector injector) {
+    public static void setInjector(Injector injector) {
         JerseyResourceConfig.injector = injector;
     }
 

--- a/rest/src/main/java/io/sparkled/rest/jetty/TryFilesFilter.java
+++ b/rest/src/main/java/io/sparkled/rest/jetty/TryFilesFilter.java
@@ -1,4 +1,4 @@
-package io.sparkled;
+package io.sparkled.rest.jetty;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;

--- a/rest/src/main/java/io/sparkled/rest/jetty/UnitOfWorkFilter.java
+++ b/rest/src/main/java/io/sparkled/rest/jetty/UnitOfWorkFilter.java
@@ -1,4 +1,4 @@
-package io.sparkled.rest;
+package io.sparkled.rest.jetty;
 
 import com.google.inject.persist.UnitOfWork;
 

--- a/rest/src/main/java/io/sparkled/rest/service/RestServiceHandler.java
+++ b/rest/src/main/java/io/sparkled/rest/service/RestServiceHandler.java
@@ -20,12 +20,28 @@ public abstract class RestServiceHandler {
 
     protected final Gson gson = GsonProvider.get();
 
-    protected Response getJsonResponse(Object responseObject) {
-        return getJsonResponse(Response.Status.OK, responseObject);
+    /**
+     * @return A 200 HTTP response with no attached entity.
+     */
+    protected Response respondOk() {
+        return Response.status(Response.Status.OK).build();
     }
 
-    protected Response getJsonResponse(Response.Status status, Object responseObject) {
-        String responseJson = gson.toJson(responseObject);
+    /**
+     * @param entity The payload to be returned as JSON.
+     * @return A 200 HTTP response an attached JSON entity.
+     */
+    protected Response respondOk(Object entity) {
+        return respond(Response.Status.OK, entity);
+    }
+
+    /**
+     * @param status The status of the HTTP response.
+     * @param entity The payload to be returned as JSON.
+     * @return An HTTP response with the specified status and an attached JSON entity.
+     */
+    protected Response respond(Response.Status status, Object entity) {
+        String responseJson = gson.toJson(entity);
 
         return Response.status(status)
                 .type(MediaType.APPLICATION_JSON_TYPE)
@@ -33,14 +49,15 @@ public abstract class RestServiceHandler {
                 .build();
     }
 
-    protected Response getBinaryResponse(Object responseObject, String mediaType) {
+    /**
+     * @param entity    The payload to be returned.
+     * @param mediaType The type of payload to be returned.
+     * @return A 200 HTTP response with the specified status and media type.
+     */
+    protected Response respondMedia(byte[] entity, String mediaType) {
         return Response.status(Response.Status.OK)
                 .type(mediaType)
-                .entity(responseObject)
+                .entity(entity)
                 .build();
-    }
-
-    protected Response getResponse(Response.Status status) {
-        return Response.status(status).build();
     }
 }

--- a/rest/src/main/java/io/sparkled/rest/service/easingtype/EasingTypeRestServiceHandler.java
+++ b/rest/src/main/java/io/sparkled/rest/service/easingtype/EasingTypeRestServiceHandler.java
@@ -8,6 +8,6 @@ import javax.ws.rs.core.Response;
 public class EasingTypeRestServiceHandler extends RestServiceHandler {
 
     public Response get() {
-        return getJsonResponse(EasingTypes.get());
+        return respondOk(EasingTypes.get());
     }
 }

--- a/rest/src/main/java/io/sparkled/rest/service/effecttype/EffectTypeRestServiceHandler.java
+++ b/rest/src/main/java/io/sparkled/rest/service/effecttype/EffectTypeRestServiceHandler.java
@@ -8,6 +8,6 @@ import javax.ws.rs.core.Response;
 public class EffectTypeRestServiceHandler extends RestServiceHandler {
 
     public Response get() {
-        return getJsonResponse(EffectTypes.get());
+        return respondOk(EffectTypes.get());
     }
 }

--- a/rest/src/main/java/io/sparkled/rest/service/filltype/FillTypeRestServiceHandler.java
+++ b/rest/src/main/java/io/sparkled/rest/service/filltype/FillTypeRestServiceHandler.java
@@ -8,6 +8,6 @@ import javax.ws.rs.core.Response;
 public class FillTypeRestServiceHandler extends RestServiceHandler {
 
     public Response get() {
-        return getJsonResponse(FillTypes.get());
+        return respondOk(FillTypes.get());
     }
 }

--- a/rest/src/main/java/io/sparkled/rest/service/player/PlayerRestServiceHandler.java
+++ b/rest/src/main/java/io/sparkled/rest/service/player/PlayerRestServiceHandler.java
@@ -26,23 +26,23 @@ public class PlayerRestServiceHandler extends RestServiceHandler {
 
     Response getAllSequences() {
         List<Playlist> playlists = playlistPersistenceService.getAllPlaylists();
-        return getJsonResponse(playlists);
+        return respondOk(playlists);
     }
 
     Response adjustPlayback(PlaylistAction action) {
         PlaylistActionType type = action.getType();
         if (type == null) {
-            return getJsonResponse(Response.Status.BAD_REQUEST, "A valid playback action must be supplied.");
+            return respond(Response.Status.BAD_REQUEST, "A valid playback action must be supplied.");
         } else if (type == PlaylistActionType.PLAY) {
             Optional<Playlist> playlist = playlistPersistenceService.getPlaylistById(action.getPlaylistId());
             if (!playlist.isPresent()) {
-                return getResponse(Response.Status.NOT_FOUND);
+                return respond(Response.Status.NOT_FOUND, "Playlist not found.");
             }
             playlistService.play(playlist.get());
         } else if (type == PlaylistActionType.STOP) {
             playlistService.stopPlayback();
         }
 
-        return getResponse(Response.Status.OK);
+        return respondOk();
     }
 }

--- a/rest/src/main/java/io/sparkled/rest/service/playlist/PlaylistRestServiceHandler.java
+++ b/rest/src/main/java/io/sparkled/rest/service/playlist/PlaylistRestServiceHandler.java
@@ -41,7 +41,7 @@ public class PlaylistRestServiceHandler extends RestServiceHandler {
     Response createPlaylist(PlaylistViewModel playlistViewModel) {
         Playlist playlist = playlistViewModelConverter.toModel(playlistViewModel);
         playlist = playlistPersistenceService.createPlaylist(playlist);
-        return getJsonResponse(new IdResponse(playlist.getId()));
+        return respondOk(new IdResponse(playlist.getId()));
     }
 
     Response getAllPlaylists() {
@@ -50,7 +50,7 @@ public class PlaylistRestServiceHandler extends RestServiceHandler {
                 .map(playlistSearchViewModelConverter::toViewModel)
                 .collect(Collectors.toList());
 
-        return getJsonResponse(results);
+        return respondOk(results);
     }
 
     Response getPlaylist(int playlistId) {
@@ -67,10 +67,10 @@ public class PlaylistRestServiceHandler extends RestServiceHandler {
                     .collect(Collectors.toList());
             viewModel.setSequences(playlistSequences);
 
-            return getJsonResponse(viewModel);
+            return respondOk(viewModel);
         }
 
-        return getResponse(Response.Status.NOT_FOUND);
+        return respond(Response.Status.NOT_FOUND, "Playlist not found.");
     }
 
     @Transactional
@@ -85,12 +85,12 @@ public class PlaylistRestServiceHandler extends RestServiceHandler {
                 .collect(Collectors.toList());
 
         playlistPersistenceService.savePlaylist(playlist, playlistSequences);
-        return getResponse(Response.Status.OK);
+        return respondOk();
     }
 
     @Transactional
     Response deletePlaylist(int id) {
         playlistPersistenceService.deletePlaylist(id);
-        return getResponse(Response.Status.OK);
+        return respondOk();
     }
 }

--- a/rest/src/main/java/io/sparkled/rest/service/renderpreview/RenderPreviewRestServiceHandler.java
+++ b/rest/src/main/java/io/sparkled/rest/service/renderpreview/RenderPreviewRestServiceHandler.java
@@ -26,7 +26,7 @@ public class RenderPreviewRestServiceHandler extends RestServiceHandler {
 
     Response getRenderedSequence(int startFrame, int durationFrames, List<SequenceChannel> sequenceChannels) {
         if (sequenceChannels == null || sequenceChannels.isEmpty()) {
-            return getJsonResponse(Response.Status.BAD_REQUEST, "Nothing to render.");
+            return respond(Response.Status.BAD_REQUEST, "Nothing to render.");
         }
 
         Optional<Sequence> sequenceOptional = sequencePersistenceService.getSequenceById(sequenceChannels.get(0).getSequenceId());
@@ -39,9 +39,9 @@ public class RenderPreviewRestServiceHandler extends RestServiceHandler {
 
             List<StageProp> stageProps = Collections.singletonList(new StageProp().setLedCount(10)); // TODO: Get from DB.
             RenderedStagePropDataMap renderResult = new Renderer(sequence, sequenceChannels, stageProps, startFrame, durationFrames).render();
-            return getJsonResponse(renderResult);
+            return respondOk(renderResult);
         } else {
-            return getResponse(Response.Status.NOT_FOUND);
+            return respond(Response.Status.NOT_FOUND, "Sequence not found.");
         }
     }
 }

--- a/rest/src/main/java/io/sparkled/rest/service/sequence/SequenceRestServiceHandler.java
+++ b/rest/src/main/java/io/sparkled/rest/service/sequence/SequenceRestServiceHandler.java
@@ -62,7 +62,7 @@ class SequenceRestServiceHandler extends RestServiceHandler {
 
         byte[] songAudioData = loadSongData(uploadedInputStream);
         int sequenceId = saveNewSequence(sequence, songAudioData);
-        return getJsonResponse(new IdResponse(sequenceId));
+        return respondOk(new IdResponse(sequenceId));
     }
 
     // TODO: Use IOUtils.toByteArray() after moving to Java 9.
@@ -83,7 +83,7 @@ class SequenceRestServiceHandler extends RestServiceHandler {
                 .map(sequenceSearchViewModelConverter::toViewModel)
                 .collect(Collectors.toList());
 
-        return getJsonResponse(results);
+        return respondOk(results);
     }
 
     Response getSequence(int sequenceId) {
@@ -100,10 +100,10 @@ class SequenceRestServiceHandler extends RestServiceHandler {
                     .collect(Collectors.toList());
             viewModel.setChannels(channels);
 
-            return getJsonResponse(viewModel);
+            return respondOk(viewModel);
         }
 
-        return getResponse(Response.Status.NOT_FOUND);
+        return respond(Response.Status.NOT_FOUND, "Sequence not found.");
     }
 
     Response getSequenceStage(int sequenceId) {
@@ -119,9 +119,9 @@ class SequenceRestServiceHandler extends RestServiceHandler {
                     .map(stagePropViewModelConverter::toViewModel)
                     .collect(Collectors.toList());
             viewModel.setStageProps(stageProps);
-            return getJsonResponse(viewModel);
+            return respondOk(viewModel);
         } else {
-            return getResponse(Response.Status.NOT_FOUND);
+            return respond(Response.Status.NOT_FOUND, "Stage not found.");
         }
     }
 
@@ -129,9 +129,9 @@ class SequenceRestServiceHandler extends RestServiceHandler {
         Optional<SongAudio> songAudio = sequencePersistenceService.getSongAudioBySequenceId(id);
 
         if (songAudio.isPresent()) {
-            return getBinaryResponse(songAudio.get().getAudioData(), SequenceRestService.MP3_MIME_TYPE);
+            return respondMedia(songAudio.get().getAudioData(), SequenceRestService.MP3_MIME_TYPE);
         } else {
-            return getResponse(Response.Status.NOT_FOUND);
+            return respond(Response.Status.NOT_FOUND, "Song audio not found.");
         }
     }
 
@@ -150,13 +150,13 @@ class SequenceRestServiceHandler extends RestServiceHandler {
         } else {
             saveDraftSequence(sequence, sequenceChannels);
         }
-        return getResponse(Response.Status.OK);
+        return respondOk();
     }
 
     @Transactional
     Response deleteSequence(int id) {
         sequencePersistenceService.deleteSequence(id);
-        return getResponse(Response.Status.OK);
+        return respondOk();
     }
 
     private void saveDraftSequence(Sequence sequence, List<SequenceChannel> sequenceChannels) {

--- a/rest/src/main/java/io/sparkled/rest/service/stage/StageRestServiceHandler.java
+++ b/rest/src/main/java/io/sparkled/rest/service/stage/StageRestServiceHandler.java
@@ -36,12 +36,12 @@ class StageRestServiceHandler extends RestServiceHandler {
     Response createStage(StageViewModel stageViewModel) {
         Stage stage = stageViewModelConverter.toModel(stageViewModel);
         stage = stagePersistenceService.createStage(stage);
-        return getJsonResponse(new IdResponse(stage.getId()));
+        return respondOk(new IdResponse(stage.getId()));
     }
 
     Response getAllStages() {
         List<Stage> stages = stagePersistenceService.getAllStages();
-        return getJsonResponse(stages);
+        return respondOk(stages);
     }
 
     Response getStage(int stageId) {
@@ -58,10 +58,10 @@ class StageRestServiceHandler extends RestServiceHandler {
                     .collect(Collectors.toList());
             viewModel.setStageProps(stageProps);
 
-            return getJsonResponse(viewModel);
+            return respondOk(viewModel);
         }
 
-        return getResponse(Response.Status.NOT_FOUND);
+        return respond(Response.Status.NOT_FOUND, "Stage not found.");
     }
 
     @Transactional
@@ -76,12 +76,12 @@ class StageRestServiceHandler extends RestServiceHandler {
                 .collect(Collectors.toList());
 
         stagePersistenceService.saveStage(stage, stageProps);
-        return getResponse(Response.Status.OK);
+        return respondOk();
     }
 
     @Transactional
     Response deleteStage(int id) {
         stagePersistenceService.deleteStage(id);
-        return getResponse(Response.Status.OK);
+        return respondOk();
     }
 }


### PR DESCRIPTION
… (#63)

Move RestApiServer and related classes from io.sparkled to io.sparkled.rest for consistency.
Improve naming and structure of RestServiceHandler methods to avoid confusion.