### PR TITLE
Fix "GP" UDP command returning stage prop UUIDs instead of codes (#155).

### DIFF
--- a/music-player/src/main/kotlin/io/sparkled/music/PlaybackState.kt
+++ b/music-player/src/main/kotlin/io/sparkled/music/PlaybackState.kt
@@ -6,16 +6,15 @@ import io.sparkled.model.entity.Song
 import io.sparkled.model.entity.SongAudio
 import io.sparkled.model.entity.StageProp
 import io.sparkled.model.render.RenderedStagePropDataMap
-import java.util.function.Supplier
 
 /**
  * A container object holding all of the information pertaining to the current state of playback, in terms of audio
  * playback and associated rendered data for streaming to clients.
  */
-data class PlaybackState constructor(
+data class PlaybackState(
     val playlist: Playlist? = null,
     val playlistIndex: Int = 0,
-    private val progressFunction: Supplier<Double>? = null,
+    private val progressFunction: () -> Double = { 0.0 },
     val sequence: Sequence? = null,
     val song: Song? = null,
     val songAudio: SongAudio? = null,
@@ -27,5 +26,5 @@ data class PlaybackState constructor(
         get() = playlist == null || sequence == null || song == null || songAudio == null || renderedStageProps == null
 
     val progress: Double
-        get() = progressFunction!!.get()
+        get() = progressFunction.invoke()
 }

--- a/music-player/src/main/kotlin/io/sparkled/music/impl/PlaybackServiceImpl.kt
+++ b/music-player/src/main/kotlin/io/sparkled/music/impl/PlaybackServiceImpl.kt
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference
-import java.util.function.Supplier
 import javax.inject.Inject
 import javax.sound.sampled.LineEvent
 import javax.sound.sampled.LineListener
@@ -100,7 +99,7 @@ class PlaybackServiceImpl
                 PlaybackState(
                     playlist = playlist,
                     playlistIndex = playlistIndex,
-                    progressFunction = Supplier { musicPlayerService.sequenceProgress },
+                    progressFunction = { musicPlayerService.sequenceProgress },
                     sequence = sequence,
                     song = song,
                     songAudio = songAudio,

--- a/udp-server/src/main/kotlin/io/sparkled/udpserver/impl/command/GetStagePropCodesCommand.kt
+++ b/udp-server/src/main/kotlin/io/sparkled/udpserver/impl/command/GetStagePropCodesCommand.kt
@@ -19,9 +19,12 @@ class GetStagePropCodesCommand : RequestCommand() {
         }
 
         val stageProps = playbackState.stageProps.values
-        val props = stageProps.map(StageProp::getUuid).joinToString(":")
+        val stagePropCodes = stageProps
+            .sortedBy(StageProp::getDisplayOrder)
+            .map(StageProp::getCode)
+            .joinToString(":")
 
-        val bytes = props.toByteArray(UTF_8)
+        val bytes = stagePropCodes.toByteArray(UTF_8)
         return if (bytes.isEmpty()) ByteArray(0) else bytes
     }
 

--- a/udp-server/src/test/kotlin/io/sparkled/udpserver/impl/command/GetStagePropCodesCommandTest.kt
+++ b/udp-server/src/test/kotlin/io/sparkled/udpserver/impl/command/GetStagePropCodesCommandTest.kt
@@ -1,0 +1,43 @@
+package io.sparkled.udpserver.impl.command
+
+import io.sparkled.model.entity.Playlist
+import io.sparkled.model.entity.Sequence
+import io.sparkled.model.entity.Song
+import io.sparkled.model.entity.SongAudio
+import io.sparkled.model.entity.StageProp
+import io.sparkled.model.render.RenderedStagePropDataMap
+import io.sparkled.model.setting.SettingsCache
+import io.sparkled.music.PlaybackState
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.Is.`is`
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+
+internal class GetStagePropCodesCommandTest {
+
+    @Test
+    fun can_retrieve_stage_prop_codes() {
+        val command = GetStagePropCodesCommand()
+        val response = command.getResponse(
+            args = listOf(GetStagePropCodesCommand.KEY),
+            settings = SettingsCache(0),
+            playbackState = PlaybackState(
+                playlist = Playlist(),
+                playlistIndex = 0,
+                progressFunction = { 0.0 },
+                sequence = Sequence(),
+                song = Song(),
+                songAudio = SongAudio(),
+                renderedStageProps = RenderedStagePropDataMap(),
+                stageProps = mapOf(
+                    "P1" to StageProp().setCode("P1").setDisplayOrder(1),
+                    "P2" to StageProp().setCode("P2").setDisplayOrder(3),
+                    "P3" to StageProp().setCode("P3").setDisplayOrder(2)
+                )
+            )
+        )
+
+        val responseString = String(response, StandardCharsets.UTF_8)
+        assertThat(responseString, `is`("P1:P3:P2"))
+    }
+}


### PR DESCRIPTION
Enforce display order of stage prop codes returned by "GP" command.